### PR TITLE
Fix redirects, and allow bare domain

### DIFF
--- a/kubernetes/app/charts/frontend/templates/config.yaml
+++ b/kubernetes/app/charts/frontend/templates/config.yaml
@@ -36,12 +36,20 @@ data:
 
             server {
                 listen 80;
+                server_name {{ .Values.ingress.host }};
                 root /usr/share/nginx/html;
                 index index.html;
 
+
+                location ^~ /.well-known/acme-challenge/ {
+                    root /usr/share/nginx/html;
+                    allow all;
+                    try_files $uri =404;  
+                }
+
                 location / {
                     try_files $uri /index.html;
-                }
+                }              
 
                 location /static/ {
                     # Allow direct serving of static assets (JS, CSS, images)
@@ -50,4 +58,18 @@ data:
 
                 error_page 404 /index.html;
             }
+
+            server {
+                server_name {{ .Values.ingress.bareDomain }};
+
+                location ^~ /.well-known/acme-challenge/ {
+                    root /usr/share/nginx/html;
+                    allow all;
+                    try_files $uri =404;
+                }
+
+                location / {
+                    return 301 https://{{ .Values.ingress.host }}$request_uri;
+                }
+            }            
         }

--- a/kubernetes/app/charts/frontend/templates/ingress.yaml
+++ b/kubernetes/app/charts/frontend/templates/ingress.yaml
@@ -25,16 +25,28 @@ metadata:
 spec:
   ingressClassName: nginx
   tls:
-    - hosts: [{{ .Values.ingress.host | quote }}]
+    - hosts:
+      {{- range $key, $value := list .Values.ingress.bareDomain .Values.ingress.host }}
+      - {{ $value | quote }}
+      {{- end }}
       secretName: {{ $tlsSecretName }} 
   rules:
-    - host: {{ .Values.ingress.host }}
+    {{- range $key, $value := list .Values.ingress.bareDomain .Values.ingress.host }}
+    - host: {{ $value | quote }}
       http:
         paths:
+          - path: "/.well-known/acme-challenge/*"  
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $.Values.service.name }}
+                port:
+                  number: {{ $.Values.service.containerPort }}
           - pathType: Prefix
             path: "/"
             backend:
               service:
-                name: {{ .Values.service.name }}
+                name: {{ $.Values.service.name }}
                 port:
-                  number: {{ .Values.service.containerPort }}
+                  number: {{ $.Values.service.containerPort }}
+    {{- end }}

--- a/kubernetes/app/charts/frontend/values.yaml
+++ b/kubernetes/app/charts/frontend/values.yaml
@@ -12,5 +12,6 @@ service:
 ingress:
   # When env is prod, set this to true to use letsencrypt staging server for prod testing
   useStagingIssuer: true
+  bareDomain: kblue.io
   host: www.kblue.io
   rps: 20

--- a/kubernetes/app/values-dev.yaml
+++ b/kubernetes/app/values-dev.yaml
@@ -32,6 +32,7 @@ frontend:
       cpu: "1"
   ingress:
     useStagingIssuer: true
+    bareDomain: kblue-dev.io
     host: www.kblue-dev.io
     rps: 10000
 

--- a/kubernetes/app/values-prod.yaml
+++ b/kubernetes/app/values-prod.yaml
@@ -24,5 +24,6 @@ frontend:
     containerPort: 80
   ingress:
     useStagingIssuer: false
+    bareDomain: kblue.io
     host: www.kblue.io
     rps: 20


### PR DESCRIPTION
Bare domain (kblue.io) now redirects to www.kblue.io. Fixed acme ingress to allow for acme challenge (when ac issues cert).