### PR TITLE
Add email-creds secret to backend deployment

### DIFF
--- a/.github/workflows/deploy_cluster.yaml
+++ b/.github/workflows/deploy_cluster.yaml
@@ -21,6 +21,7 @@ jobs:
       - run: kubectl create ns cert-manager || echo
       - run: kubectl create secret docker-registry regcred --docker-server=https://registry.gitlab.com --docker-username=${{ secrets.GITLAB_USERNAME }} --docker-password=${{ secrets.GITLAB_TOKEN }} --docker-email=${{ secrets.GITLAB_EMAIL }} -n app || echo
       - run: kubectl create secret generic psql-password --from-literal=POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }} -n app || echo
+      - run: kubectl create secret generic email-creds --from-literal=EMAIL_ADDRESS='${{ secrets.BOT_EMAIL_ADDRESS }}' --from-literal=EMAIL_PASSWORD='${{ secrets.BOT_EMAIL_PASSWORD }}' -n app || echo
   apply_helmfile:
     runs-on: ubuntu-latest
     container:

--- a/kubernetes/app/charts/backend/templates/deployment.yaml
+++ b/kubernetes/app/charts/backend/templates/deployment.yaml
@@ -27,6 +27,8 @@ spec:
           env:
             - name: ENVIRONMENT
               value: {{ include "environment" . }}
+            - name: ALLOWED_ORIGINS
+              value: {{ join ", " .Values.service.allowedOrigins }}
             {{- range $key, $value := .Values.service.envVars }}
             - name: {{ $key }}
               value: {{ $value }}
@@ -36,6 +38,9 @@ spec:
           envFrom:
             - secretRef:
                 name: psql-password
+                optional: false
+            - secretRef:
+                name: email-creds
                 optional: false
       {{- if eq (include "environment" .) "dev" }}
           volumeMounts:

--- a/kubernetes/app/charts/backend/values.yaml
+++ b/kubernetes/app/charts/backend/values.yaml
@@ -4,6 +4,8 @@ service:
   numReplicas: 1
   containerPort: 8080
   envVars: {}
+  allowedOrigins:
+    - "https://www.kblue.io"
   resources:
     isHardLimit: true
     memory: "512M"

--- a/kubernetes/app/values-dev.yaml
+++ b/kubernetes/app/values-dev.yaml
@@ -15,6 +15,8 @@ backend:
     containerPort: 8080
     resources:
       isHardLimit: false
+    allowedOrigins:
+      - "https://www.kblue-dev.io"
   ingress:
     useStagingIssuer: true
     host: api.kblue-dev.io

--- a/kubernetes/app/values-prod.yaml
+++ b/kubernetes/app/values-prod.yaml
@@ -12,6 +12,8 @@ backend:
     image: registry.gitlab.com/bigboiblue/kblue-io-registry/backend:latest
     numReplicas: 1
     containerPort: 8080
+    allowedOrigins:
+      - "https://www.kblue.io"
   ingress:
     useStagingIssuer: false
     host: api.kblue.io

--- a/kubernetes/prepare-hook.sh
+++ b/kubernetes/prepare-hook.sh
@@ -33,6 +33,11 @@ if ! kubectl get secret ssh-keys -n app; then
     MISSING_RESOURCES="Secret 'ssh-keys' is missing in 'app' namespace.\n$MISSING_RESOURCES"
 fi
 
+if ! kubectl get secret email-creds -n app; then
+    MISSING_RESOURCES="Secret 'email-creds' is missing in 'app' namespace.\n$MISSING_RESOURCES"
+fi
+
+
 if [ -n "$MISSING_RESOURCES" ]; then
     echo "---"
     echo -e "Before releasing anything with Helm, please add the required preliminary resources:\n$MISSING_RESOURCES\nSee README for more info."


### PR DESCRIPTION
Backend requires email creds to access bot email. Creds are loaded via env vars through github action secrets.